### PR TITLE
Fix false positive when detecting unknown objects in component state

### DIFF
--- a/Source/SafetySharp/Modeling/ModelBase.cs
+++ b/Source/SafetySharp/Modeling/ModelBase.cs
@@ -38,6 +38,8 @@ namespace SafetySharp.Modeling
 	{
 		private IComponent[] _components;
 		private Fault[] _faults;
+
+		[Hidden]
 		private object[] _referencedObjects;
 		private IComponent[] _roots;
 


### PR DESCRIPTION
After the update to S# 1.2.0, everytime I tried to run a model check on my model, an exception was thrown complaining about an unknown object of type `System.Object[]`. Since I didn't create this in my model, I debugged S# and figured out the offending array was `ModelBase._referencedObjects`.

`git bisect` revealed this problem was introduced in 8659dba020. I'm not sure what exactly causes it to surface, since the case studies seem to work fine (maybe a component holding a reference to the `Model` instance?).

This commit fixes the problem by marking the field `[Hidden]`. Not sure if that's the appropriate solution, but it seems to work in my case.