### PR TITLE
Don't generate fault sets with suppressed faults

### DIFF
--- a/Source/SafetySharp/Analysis/SafetyAnalysis.cs
+++ b/Source/SafetySharp/Analysis/SafetyAnalysis.cs
@@ -120,6 +120,7 @@ namespace SafetySharp.Analysis
 			var forcedFaults = allFaults.Where(fault => fault.Activation == Activation.Forced).ToArray();
 			var suppressedFaults = allFaults.Where(fault => fault.Activation == Activation.Suppressed).ToArray();
 			var nondeterministicFaults = allFaults.Where(fault => fault.Activation == Activation.Nondeterministic).ToArray();
+			var nonSuppressedFaults = allFaults.Where(fault => fault.Activation != Activation.Suppressed).ToArray();
 
 			_suppressedSet = new FaultSet(suppressedFaults);
 			_forcedSet = new FaultSet(forcedFaults);
@@ -155,7 +156,7 @@ namespace SafetySharp.Analysis
 			for (var cardinality = 0; cardinality <= allFaults.Length; ++cardinality)
 			{
 				// Generate the sets for the current level that we'll have to check
-				var sets = GeneratePowerSetLevel(cardinality, allFaults, currentSafe);
+				var sets = GeneratePowerSetLevel(cardinality, nonSuppressedFaults, currentSafe);
 				currentSafe.Clear();
 
 				// Remove all sets that conflict with the forced or suppressed faults; these sets are considered to be safe.


### PR DESCRIPTION
Instead of generating them and then filtering them out, do not generate them. The filtering is still necessary for forced faults and for sets suggested by heuristics.