### PR TITLE
Performance Improvements for Heuristics

### DIFF
--- a/Source/SafetySharp/Analysis/FaultSet.cs
+++ b/Source/SafetySharp/Analysis/FaultSet.cs
@@ -225,18 +225,9 @@ namespace SafetySharp.Analysis
 		/// <param name="allFaults">The list of all analyzed faults.</param>
 		internal static FaultSet SubsumedFaults(FaultSet set, Fault[] allFaults)
 		{
-			var currentFaults = set.ToFaultSequence(allFaults);
-			var subsumed = set;
-
-			uint oldCount;
-			do // fixed-point iteration
-			{
-				oldCount = subsumed.Cardinality;
-				currentFaults = currentFaults.SelectMany(fault => fault.SubsumedFaults);
-				subsumed = subsumed.GetUnion(new FaultSet(currentFaults));
-			} while (oldCount < subsumed.Cardinality);
-
-			return subsumed;
+			// Fault class performs fixed-point iteration and caches the result for performance reasons
+			return set.ToFaultSequence(allFaults)
+				.Aggregate(set, (subsumed, fault) => subsumed.GetUnion(fault.SubsumedFaultSet));
 		}
 
 		/// <summary>

--- a/Source/SafetySharp/Analysis/Heuristics/IFaultSetHeuristic.cs
+++ b/Source/SafetySharp/Analysis/Heuristics/IFaultSetHeuristic.cs
@@ -34,12 +34,12 @@ namespace SafetySharp.Analysis.Heuristics
 		/// </summary>
 		/// <param name="cardinalityLevel">The level of cardinality that is currently checked.</param>
 		/// <param name="setsToCheck">The next sets to be checked, in reverse order (the last set is checked first).</param>
-		void Augment(uint cardinalityLevel, List<FaultSet> setsToCheck);
+		void Augment(uint cardinalityLevel, LinkedList<FaultSet> setsToCheck);
 
 		/// <summary>
 		///   Informs the heuristic of the result of analyzing <paramref name="checkedSet" />
 		///   and allows it to adapt the sets to check next.
 		/// </summary>
-		void Update(List<FaultSet> setsToCheck, FaultSet checkedSet, bool isSafe);
+		void Update(LinkedList<FaultSet> setsToCheck, FaultSet checkedSet, bool isSafe);
 	}
 }

--- a/Source/SafetySharp/Analysis/Heuristics/MaximalSafeSetHeuristic.cs
+++ b/Source/SafetySharp/Analysis/Heuristics/MaximalSafeSetHeuristic.cs
@@ -76,7 +76,7 @@ namespace SafetySharp.Analysis.Heuristics
 		/// </summary>
 		/// <param name="cardinalityLevel">The level of cardinality that is currently checked.</param>
 		/// <param name="setsToCheck">The next sets to be checked, in reverse order (the last set is checked first).</param>
-		public void Augment(uint cardinalityLevel, List<FaultSet> setsToCheck)
+		public void Augment(uint cardinalityLevel, LinkedList<FaultSet> setsToCheck)
 		{
 			if (setsToCheck.Count == 0 || _minimalCriticalSets.Count == 0 || _cardinalityLevel > cardinalityLevel || !_hasNewMinimalCriticalSets)
 				return;
@@ -85,16 +85,17 @@ namespace SafetySharp.Analysis.Heuristics
 			_hasNewMinimalCriticalSets = false;
 
 			foreach (var set in RemoveAllFaults(new FaultSet(), 0))
+			{
+				setsToCheck.AddFirst(set);
 				_suggestedSets.Add(_allFaults.GetDifference(set));
-
-			setsToCheck.AddRange(_suggestedSets);
+			}
 		}
 
 		/// <summary>
 		///   Informs the heuristic of the result of analyzing <paramref name="checkedSet" />
 		///   and allows it to adapt the sets to check next.
 		/// </summary>
-		public void Update(List<FaultSet> setsToCheck, FaultSet checkedSet, bool isSafe)
+		public void Update(LinkedList<FaultSet> setsToCheck, FaultSet checkedSet, bool isSafe)
 		{
 			// Ignore critical sets we've suggested ourself as these are likely not minimal and
 			// would degrade the quality of our suggestions

--- a/Source/SafetySharp/Analysis/Heuristics/MinimalRedundancyHeuristic.cs
+++ b/Source/SafetySharp/Analysis/Heuristics/MinimalRedundancyHeuristic.cs
@@ -85,13 +85,14 @@ namespace SafetySharp.Analysis.Heuristics
 			_nextSuggestions = GetSubsets(_currentSuggestions);
 		}
 
-		void IFaultSetHeuristic.Augment(uint cardinalityLevel, List<FaultSet> setsToCheck)
+		void IFaultSetHeuristic.Augment(uint cardinalityLevel, LinkedList<FaultSet> setsToCheck)
 		{
 			_successCounter = 0;
-			setsToCheck.AddRange(_currentSuggestions);
+			foreach (var suggestion in _currentSuggestions)
+				setsToCheck.AddFirst(suggestion);
 		}
 
-		void IFaultSetHeuristic.Update(List<FaultSet> setsToCheck, FaultSet checkedSet, bool isSafe)
+		void IFaultSetHeuristic.Update(LinkedList<FaultSet> setsToCheck, FaultSet checkedSet, bool isSafe)
 		{
 			var isSuggestion = _currentSuggestions.Remove(checkedSet);
 			if (!isSuggestion)
@@ -129,7 +130,7 @@ namespace SafetySharp.Analysis.Heuristics
 				from excludedFaults in CartesianProduct(faultGroups)
 				// also exclude subsuming faults
 				let subsuming = FaultSet.SubsumingFaults(excludedFaults, _allFaults)
-				orderby subsuming.Cardinality descending
+				orderby subsuming.Cardinality ascending
 				select faults.GetDifference(subsuming)
 				);
 		}

--- a/Source/SafetySharp/Analysis/Heuristics/SubsumptionHeuristic.cs
+++ b/Source/SafetySharp/Analysis/Heuristics/SubsumptionHeuristic.cs
@@ -46,45 +46,52 @@ namespace SafetySharp.Analysis.Heuristics
 			_allFaults = model.Faults;
 		}
 
-		void IFaultSetHeuristic.Augment(uint cardinalityLevel, List<FaultSet> setsToCheck)
+		void IFaultSetHeuristic.Augment(uint cardinalityLevel, LinkedList<FaultSet> setsToCheck)
 		{
 			// for each set, check the set of subsumed faults first
-			for (var i = 0; i < setsToCheck.Count; ++i)
+			for (var node = setsToCheck.First; node != null; node = node.Next)
 			{
-				var subsumed = FaultSet.SubsumedFaults(setsToCheck[i], _allFaults);
-				if (!setsToCheck[i].Equals(subsumed) && !_subsumedSets.Contains(subsumed))
+				var subsumed = FaultSet.SubsumedFaults(node.Value, _allFaults);
+				if (!node.Value.Equals(subsumed) && !_subsumedSets.Contains(subsumed))
 				{
-					setsToCheck.Insert(i + 1, subsumed);
+					setsToCheck.AddBefore(node, subsumed);
 					_subsumedSets.Add(subsumed);
-					i++;
 				}
 			}
 		}
 
-		void IFaultSetHeuristic.Update(List<FaultSet> setsToCheck, FaultSet checkedSet, bool isSafe)
+		void IFaultSetHeuristic.Update(LinkedList<FaultSet> setsToCheck, FaultSet checkedSet, bool isSafe)
 		{
 			if (!_subsumedSets.Contains(checkedSet))
 				return;
 
-			var delta = isSafe ? 1 : -1;
-			_successCounter += delta;
-
+			_successCounter += isSafe ? 1 : -1;
 			if (_successCounter != 0)
 				return;
 
 			// if the subsumed sets are critical more often than they are not,
 			// check the "normal" sets first.
-			for (var i = 0; i < setsToCheck.Count; ++i)
+			for (var node = setsToCheck.First; node != null; node = node.Next)
 			{
-				var set = setsToCheck[i];
+				var set = node.Value;
 				if (_subsumedSets.Contains(set))
 				{
-					setsToCheck[i] = setsToCheck[i + delta];
-					setsToCheck[i + delta] = set;
-					if (isSafe) // we just moved 'set' to position i+1
-						i++; // skip it, don't move it again
+					if (isSafe && node.Previous != null) // move subsumed set before set
+						SwitchValues(node, node.Previous);
+					else if (!isSafe && node.Next != null) // move subsumed set after set
+					{
+						SwitchValues(node, node.Next);
+						node = node.Next; // skip iteration for node.Next
+					}
 				}
 			}
+		}
+
+		private void SwitchValues(LinkedListNode<FaultSet> node1, LinkedListNode<FaultSet> node2)
+		{
+			var tmp = node1.Value;
+			node1.Value = node2.Value;
+			node2.Value = tmp;
 		}
 	}
 }

--- a/Source/SafetySharp/Analysis/SafetyAnalysis.cs
+++ b/Source/SafetySharp/Analysis/SafetyAnalysis.cs
@@ -188,7 +188,7 @@ namespace SafetySharp.Analysis
 					ConsoleHelpers.WriteLine($"Checking {sets.Count} sets of cardinality {cardinality}...");
 
 				// use heuristics
-				var setsToCheck = new List<FaultSet>(sets);
+				var setsToCheck = new LinkedList<FaultSet>(sets);
 				foreach (var heuristic in Heuristics)
 				{
 					var count = setsToCheck.Count;
@@ -204,10 +204,10 @@ namespace SafetySharp.Analysis
 				// We have to check each set - heuristics may add further during the loop
 				while (setsToCheck.Count > 0)
 				{
-					var set = setsToCheck[setsToCheck.Count - 1];
+					var set = setsToCheck.First.Value;
 
 					var isCurrentLevel = sets.Remove(set); // returns true if set was actually contained
-					setsToCheck.RemoveAt(setsToCheck.Count - 1);
+					setsToCheck.RemoveFirst();
 
 					// for current level, we already know the set is valid
 					var isValid = isCurrentLevel || IsValid(set);

--- a/Tests/Analysis/Heuristics/fault subsumption.cs
+++ b/Tests/Analysis/Heuristics/fault subsumption.cs
@@ -23,7 +23,7 @@
 namespace Tests.Analysis.Heuristics
 {
 	using System;
-	using System.Linq;
+	using System.Collections.Generic;
 	using SafetySharp.Analysis;
 	using SafetySharp.Analysis.Heuristics;
 	using SafetySharp.Modeling;
@@ -39,7 +39,7 @@ namespace Tests.Analysis.Heuristics
 
 			// no subsumption declared
 			IFaultSetHeuristic heuristic = new SubsumptionHeuristic(model);
-			var setsToCheck = new[] { new FaultSet(c.F1), new FaultSet(c.F2) }.ToList();
+			var setsToCheck = new LinkedList<FaultSet>(new[] { new FaultSet(c.F1), new FaultSet(c.F2) });
 			heuristic.Augment(0, setsToCheck);
 			setsToCheck.Count.ShouldBe(2);
 
@@ -48,34 +48,34 @@ namespace Tests.Analysis.Heuristics
 			c.F1.Subsumes(c.F2);
 			heuristic.Augment(0, setsToCheck);
 			setsToCheck.Count.ShouldBe(3);
-			setsToCheck.ShouldBe(new[] { new FaultSet(c.F1), new FaultSet(c.F1, c.F2), new FaultSet(c.F2) });
+			setsToCheck.ShouldBe(new[] { new FaultSet(c.F1, c.F2), new FaultSet(c.F1), new FaultSet(c.F2) });
 
 			// transitive subsumption
 			heuristic = new SubsumptionHeuristic(model);
-			setsToCheck = new[] { new FaultSet(c.F1), new FaultSet(c.F2) }.ToList();
+			setsToCheck = new LinkedList<FaultSet>(new[] { new FaultSet(c.F1), new FaultSet(c.F2) });
 			c.F2.Subsumes(c.F3);
 			heuristic.Augment(0, setsToCheck);
 			setsToCheck.Count.ShouldBe(4);
-			setsToCheck.ShouldBe(new[] { new FaultSet(c.F1), new FaultSet(c.F1, c.F2, c.F3),
-				new FaultSet(c.F2), new FaultSet(c.F2, c.F3) });
+			setsToCheck.ShouldBe(new[] { new FaultSet(c.F1, c.F2, c.F3), new FaultSet(c.F1),
+				new FaultSet(c.F2, c.F3), new FaultSet(c.F2) });
 
 			// reflexive subsumption (nonsensical, but should be handled without endless loop)
 			heuristic = new SubsumptionHeuristic(model);
-			setsToCheck = new[] { new FaultSet(c.F3) }.ToList();
+			setsToCheck = new LinkedList<FaultSet>(new[] { new FaultSet(c.F3) });
 			c.F3.Subsumes(c.F3);
 			heuristic.Augment(0, setsToCheck);
 			setsToCheck.ShouldBe(new[] { new FaultSet(c.F3) });
 
 			// circular subsumption
 			heuristic = new SubsumptionHeuristic(model);
-			setsToCheck = new[] { new FaultSet(c.F2) }.ToList();
+			setsToCheck = new LinkedList<FaultSet>(new[] { new FaultSet(c.F2) });
 			c.F3.Subsumes(c.F2);
 			heuristic.Augment(0, setsToCheck);
-			setsToCheck.ShouldBe(new[] { new FaultSet(c.F2), new FaultSet(c.F2, c.F3) }, false, "circular");
+			setsToCheck.ShouldBe(new[] { new FaultSet(c.F2, c.F3), new FaultSet(c.F2) });
 
 			// empty set subsumes nothing
 			heuristic = new SubsumptionHeuristic(model);
-			setsToCheck = new[] { new FaultSet() }.ToList();
+			setsToCheck = new LinkedList<FaultSet>(new[] { new FaultSet() });
 			heuristic.Augment(0, setsToCheck);
 			setsToCheck.Count.ShouldBe(1);
 		}

--- a/Tests/Analysis/Heuristics/heuristic with forced and suppressed.cs
+++ b/Tests/Analysis/Heuristics/heuristic with forced and suppressed.cs
@@ -67,14 +67,14 @@ namespace Tests.Analysis.Heuristics
 		{
 			public C C { get; set; }
 
-			public void Augment(uint cardinalityLevel, List<FaultSet> setsToCheck)
+			public void Augment(uint cardinalityLevel, LinkedList<FaultSet> setsToCheck)
 			{
-				setsToCheck.Add(new FaultSet());
-				setsToCheck.Add(new FaultSet(C.F1, C.F2));
-				setsToCheck.Add(new FaultSet(C.F1));
+				setsToCheck.AddFirst(new FaultSet());
+				setsToCheck.AddFirst(new FaultSet(C.F1, C.F2));
+				setsToCheck.AddFirst(new FaultSet(C.F1));
 			}
 
-			public void Update(List<FaultSet> setsToCheck, FaultSet checkedSet, bool isSafe)
+			public void Update(LinkedList<FaultSet> setsToCheck, FaultSet checkedSet, bool isSafe)
 			{
 			}
 		}

--- a/Tests/Analysis/Heuristics/heuristics integration.cs
+++ b/Tests/Analysis/Heuristics/heuristics integration.cs
@@ -76,7 +76,7 @@ namespace Tests.Analysis.Heuristics
 			result.IsComplete.ShouldBe(true);
 			result.Exceptions.ShouldBeEmpty();
 			result.MinimalCriticalSets.ShouldBeEmpty();
-			result.CheckedSets.Count.ShouldBe(985);
+			result.CheckedSets.Count.ShouldBe(6561);
 			((ulong)result.CheckedSets.Count).ShouldBeLessThan(counter.setCounter); // heuristic has effect
 
 			// heuristics are called appropriately when combined
@@ -96,14 +96,14 @@ namespace Tests.Analysis.Heuristics
 		{
 			public int cardinalityCounter = 0;
 
-			public void Augment(uint cardinalityLevel, List<FaultSet> setsToCheck)
+			public void Augment(uint cardinalityLevel, LinkedList<FaultSet> setsToCheck)
 			{
 				cardinalityCounter++;
 			}
 
 			public ulong setCounter = 0;
 
-			public void Update(List<FaultSet> setsToCheck, FaultSet checkedSet, bool isSafe)
+			public void Update(LinkedList<FaultSet> setsToCheck, FaultSet checkedSet, bool isSafe)
 			{
 				setCounter++;
 			}

--- a/Tests/Analysis/Heuristics/incorrect heuristic.cs
+++ b/Tests/Analysis/Heuristics/incorrect heuristic.cs
@@ -55,17 +55,17 @@ namespace Tests.Analysis.Heuristics
 		{
 			public C C { get; set; }
 
-			public void Augment(uint cardinalityLevel, List<FaultSet> setsToCheck)
+			public void Augment(uint cardinalityLevel, LinkedList<FaultSet> setsToCheck)
 			{
-				setsToCheck.Add(new FaultSet(C.F1));
+				setsToCheck.AddFirst(new FaultSet(C.F1));
 			}
 
 			private bool updated = false;
-			public void Update(List<FaultSet> setsToCheck, FaultSet checkedSet, bool isSafe)
+			public void Update(LinkedList<FaultSet> setsToCheck, FaultSet checkedSet, bool isSafe)
 			{
 				if (updated)
 					return;
-				setsToCheck.Add(new FaultSet(C.F2));
+				setsToCheck.AddFirst(new FaultSet(C.F2));
 				updated = true;
 			}
 		}

--- a/Tests/Analysis/Heuristics/minimal redundancy heuristic.cs
+++ b/Tests/Analysis/Heuristics/minimal redundancy heuristic.cs
@@ -44,7 +44,7 @@ namespace Tests.Analysis.Heuristics
 				components.Select(c => c.F3)
 			);
 
-			var setsToCheck = new List<FaultSet>();
+			var setsToCheck = new LinkedList<FaultSet>();
 			heuristic.Augment(0, setsToCheck);
 
 			setsToCheck.Count.ShouldBe(125);


### PR DESCRIPTION
Use linked lists for faster inserts. Cache transitively subsumed faults.